### PR TITLE
Install selinux python binding for CentOS

### DIFF
--- a/01-init-env.sh
+++ b/01-init-env.sh
@@ -30,13 +30,8 @@ else
     echo "This Linux Distribution is NOT supported"
 fi
 pip install --upgrade pip
-pip install 'pbr>=1.6'
-pip install 'ansible>=2.4.0'
-pip install 'netaddr'
-pip install 'jinja2>=2.9.6'
 pip install 'pyOpenSSL==16.2.0'
 pip install 'python-openstackclient==3.12.0'
-
 
 swapoff -a
 modprobe rbd


### PR DESCRIPTION
And don't install python modules required for Kubespray in script 01.
It is handled in script 02.