### PR TITLE
Update 02-install-k8s.sh

### DIFF
--- a/02-install-k8s.sh
+++ b/02-install-k8s.sh
@@ -62,8 +62,7 @@ kubectl create clusterrolebinding ceph \
 --clusterrole=cluster-admin \
 --serviceaccount=ceph:default
 
-echo """nameserver 10.96.0.10
-nameserver 8.8.8.8
+echo """nameserver 8.8.8.8
 nameserver 8.8.4.4
 search openstack.svc.cluster.local svc.cluster.local cluster.local
 options ndots:5""" > /etc/resolv.conf


### PR DESCRIPTION
nameserver 설정 오류로 아래 에러 발생
 ERROR armada grpc._channel._Rendezvous: <_Rendezvous of RPC that terminated with (StatusCode.UNKNOWN, Get https://10.96.0.1:443/api/v1/namespaces/kube-system/configmaps?labelSelector=OWNER%3DTILLER: dial tcp 10.96.0.1:443: getsockopt: no route to host)>

nameserver 10.96.0.10 삭제